### PR TITLE
Update ecommerce-order-example.php

### DIFF
--- a/examples/ecommerce-order-example.php
+++ b/examples/ecommerce-order-example.php
@@ -2,18 +2,14 @@
 
 date_default_timezone_set('America/Sao_Paulo');
 
-// FIX: MOZG
-
 $depth = 3;
 $path = dirname(__FILE__);
-for( $d=1 ; $d <= $depth ; $d++ ){
+for( $d=1 ; $d <= $depth ; $d++ ) {
     $path = dirname($path);
 }
 $vendorModuleDir = $path;
 
 $autoload_path = $vendorModuleDir . '/autoload.php';
-
-//print_r($autoload_path);
 
 $included = include $autoload_path;
 
@@ -21,8 +17,6 @@ if (!$included) {
     echo 'Falha no carregamento do autoload';
     exit(1);
 }
-
-// FIX: MOZG
 
 use ClearSale\ClearSaleAnalysis;
 use ClearSale\Environment\Sandbox;

--- a/examples/ecommerce-order-example.php
+++ b/examples/ecommerce-order-example.php
@@ -7,9 +7,9 @@ $path = dirname(__FILE__);
 for( $d=1 ; $d <= $depth ; $d++ ) {
     $path = dirname($path);
 }
-$vendorModuleDir = $path;
+$vendorDir = $path;
 
-$autoload_path = $vendorModuleDir . '/autoload.php';
+$autoload_path = $vendorDir . '/autoload.php';
 
 $included = include $autoload_path;
 

--- a/examples/ecommerce-order-example.php
+++ b/examples/ecommerce-order-example.php
@@ -2,7 +2,27 @@
 
 date_default_timezone_set('America/Sao_Paulo');
 
-require __DIR__.'/../vendor/autoload.php';
+// FIX: MOZG
+
+$depth = 3;
+$path = dirname(__FILE__);
+for( $d=1 ; $d <= $depth ; $d++ ){
+    $path = dirname($path);
+}
+$vendorModuleDir = $path;
+
+$autoload_path = $vendorModuleDir . '/autoload.php';
+
+//print_r($autoload_path);
+
+$included = include $autoload_path;
+
+if (!$included) {
+    echo 'Falha no carregamento do autoload';
+    exit(1);
+}
+
+// FIX: MOZG
 
 use ClearSale\ClearSaleAnalysis;
 use ClearSale\Environment\Sandbox;


### PR DESCRIPTION
Boa Tarde

Criei uma pasta /test

Criei um arquivo composer.json com o seguinte conteudo

```
{
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require": {
      "lucasmro/clearsale": "*"
   }
}
```

No terminal executei o comando

```
composer install
```

Foi feito o download 
- Installing lucasmro/clearsale (v1.2.0)
  Loading from cache

Acessei 

http://127.0.0.1/public_html/test/vendor/lucasmro/clearsale/examples/ecommerce-order-example.php

e foi exibido o erro

```
Warning: require(/home/marcio/dados/public_html/test/vendor/lucasmro/clearsale/examples/../vendor/autoload.php): failed to open stream: No such file or directory in /home/marcio/dados/public_html/test/vendor/lucasmro/clearsale/examples/ecommerce-order-example.php on line 5

Fatal error: require(): Failed opening required '/home/marcio/dados/public_html/test/vendor/lucasmro/clearsale/examples/../vendor/autoload.php' (include_path='.:/usr/share/php') in /home/marcio/dados/public_html/test/vendor/lucasmro/clearsale/examples/ecommerce-order-example.php on line 5
```

Editei o meu arquivo local

/home/marcio/dados/public_html/test/vendor/lucasmro/clearsale/examples/ecommerce-order-example.php

alterando o trecho

DE

```
require __DIR__.'/../vendor/autoload.php';
```

PARA

```
// FIX: MOZG

$depth = 3;
$path = dirname(__FILE__);
for( $d=1 ; $d <= $depth ; $d++ ){
    $path = dirname($path);
}
$vendorModuleDir = $path;

$autoload_path = $vendorModuleDir . '/autoload.php';

//print_r($autoload_path);

$included = include $autoload_path;

if (!$included) {
    echo 'Falha no carregamento do autoload';
    exit(1);
}

// FIX: MOZG
```

Agora funcionou o apontamento para o autoload

Veja os passos a passo conforme imagens

http://pasteboard.co/14wN8iVD.png

http://pasteboard.co/103Oz0bk.png

http://pasteboard.co/14wRm0bp.png

http://pasteboard.co/14wSRoNC.png

http://pasteboard.co/14wUrEzg.png
