### PR TITLE
Fixed the property name of getters methods

### DIFF
--- a/src/ClearSale/XmlEntity/SendOrder/Order.php
+++ b/src/ClearSale/XmlEntity/SendOrder/Order.php
@@ -598,7 +598,7 @@ class Order
      */
     public function getBillingData()
     {
-        return $this->billingData;
+        return $this->customerBillingData;
     }
 
     /**
@@ -619,7 +619,7 @@ class Order
      */
     public function getShippingData()
     {
-        return $this->shippingData;
+        return $this->customerShippingData;
     }
 
     /**


### PR DESCRIPTION
This PR fixes the property name of `getShippingData` and `getBillingData` methods of class `ClearSale\XmlEntity\SendOrder`. The previous version refers to wrong property name.
