### PR TITLE
Correção status de Suspensão Manual

### DIFF
--- a/src/ClearSale/ClearSaleAnalysis.php
+++ b/src/ClearSale/ClearSaleAnalysis.php
@@ -130,7 +130,6 @@ class ClearSaleAnalysis
     {
         switch ($packageStatus->getOrder()->getStatus()) {
             case OrderReturn::STATUS_SAIDA_REPROVADA_SEM_SUSPEITA:
-            case OrderReturn::STATUS_SAIDA_SUSPENSAO_MANUAL:
             case OrderReturn::STATUS_SAIDA_CANCELADO_PELO_CLIENTE:
             case OrderReturn::STATUS_SAIDA_FRAUDE_CONFIRMADA:
             case OrderReturn::STATUS_SAIDA_REPROVACAO_AUTOMATICA:
@@ -146,6 +145,7 @@ class ClearSaleAnalysis
         switch ($packageStatus->getOrder()->getStatus()) {
             case OrderReturn::STATUS_SAIDA_ANALISE_MANUAL:
             case OrderReturn::STATUS_SAIDA_NOVO:
+            case OrderReturn::STATUS_SAIDA_SUSPENSAO_MANUAL:                
                 return true;
             default:
                 return false;


### PR DESCRIPTION
O status 'SUS' não é estado final da análise, podendo o mesmo mudar para 'APM' aprovação manual.
Isto significa que 'SUS' ainda está na espera da aprovação.