### PR TITLE
Fix method's name from addItems to addItem

### DIFF
--- a/src/ClearSale/XmlEntity/SendOrder/Order.php
+++ b/src/ClearSale/XmlEntity/SendOrder/Order.php
@@ -696,7 +696,7 @@ class Order
     public function setItems($items)
     {
         foreach ($items as $item) {
-            $this->addItems($item);
+            $this->addItem($item);
         }
 
         return $this;


### PR DESCRIPTION
Fix method's name from addItems to addItem, because addItems does not exist