### PR TITLE
Adding complement parameter on Address' constructor

### DIFF
--- a/src/ClearSale/XmlEntity/SendOrder/Address.php
+++ b/src/ClearSale/XmlEntity/SendOrder/Address.php
@@ -19,7 +19,7 @@ class Address implements XmlEntityInterface
     private $zipCode;
     private $reference;
 
-    public static function create($street, $number, $county, $country, $city, $state, $zipCode)
+    public static function create($street, $number, $county, $country, $city, $state, $zipCode, $complement = '')
     {
         $instance = new self();
 
@@ -30,6 +30,10 @@ class Address implements XmlEntityInterface
         $instance->setCity($city);
         $instance->setState($state);
         $instance->setZipCode($zipCode);
+
+        if (!empty($complement)) {
+            $instance->setComplement($complement);
+        }
 
         return $instance;
     }


### PR DESCRIPTION
Adding complement parameter on Address' constructor with empty value to use when is necessary!

I sent some orders to ClearSale and they ask me about send some orders with complement. So, I needed to create this parameter to set this information through constructor Address class!